### PR TITLE
Bugfix: Ghost bullet at start of wave

### DIFF
--- a/src/targeting.c
+++ b/src/targeting.c
@@ -59,6 +59,7 @@ void Targeting_Reset(void)
   targeting_dmgacc[tpos] = 0U;
   targeting_cooldown[tpos] = 0U;
  }
+ Bullet_Reset();
 }
 
 


### PR DESCRIPTION
Due to a missing reset, bullets from a previous wave could remain to show up on the subsequent wave. Was especially apparent with bomb fragments from cannons.