### PR TITLE
Automatic Undo

### DIFF
--- a/src/playfield.c
+++ b/src/playfield.c
@@ -413,14 +413,14 @@ playfield_swapresult_tdef Playfield_Swap(
  }
  if (Playfield_IsRestoringSwap(xpos1, ypos1, xpos2, ypos2)){
   playfield_isrestorable = false;
-  result = PLAYFIELD_SWAP_OK;
+  result = PLAYFIELD_SWAP_RESTORE;
  }else{
   playfield_prev_xpos1 = xpos1;
   playfield_prev_ypos1 = ypos1;
   playfield_prev_xpos2 = xpos2;
   playfield_prev_ypos2 = ypos2;
   playfield_isrestorable = true;
-  result = PLAYFIELD_SWAP_RESTORE;
+  result = PLAYFIELD_SWAP_OK;
  }
  playfield_acts[ypos1][xpos1] = PLAYFIELD_ACT_SWAP1 << 4;
  playfield_acts[ypos2][xpos2] = PLAYFIELD_ACT_SWAP2 << 4;

--- a/src/playfield.h
+++ b/src/playfield.h
@@ -75,6 +75,13 @@
 #define PLAYFIELD_ACT_MATCH 5U
 /** @} */
 
+/** Swap result types */
+typedef enum{
+ PLAYFIELD_SWAP_FAIL,
+ PLAYFIELD_SWAP_OK,
+ PLAYFIELD_SWAP_RESTORE
+}playfield_swapresult_tdef;
+
 
 /** Playfield activity report structure */
 typedef struct{
@@ -111,9 +118,27 @@ void Playfield_Tick(playfield_activity_tdef* report);
  * @param   ypos1:  Y position of item 1
  * @param   xpos2:  X position of item 2
  * @param   ypos2:  Y position of item 2
- * @return          True if a swap is initiated (both items are valid)
+ * @return          Result of swap
  */
-bool Playfield_Swap(
+playfield_swapresult_tdef Playfield_Swap(
+    uint_fast8_t xpos1, uint_fast8_t ypos1,
+    uint_fast8_t xpos2, uint_fast8_t ypos2);
+
+/**
+ * @brief   Check if a swap would restore state before
+ *
+ * This can be used for implementing an undo feature. Returns true if the
+ * swap would restore state before a previous swap. This doesn't change the
+ * state of the playfield, Playfield_Swap() still has to be called with the
+ * same parameters to do so (which this case would succeed).
+ *
+ * @param   xpos1:  X position of item 1
+ * @param   ypos1:  Y position of item 1
+ * @param   xpos2:  X position of item 2
+ * @param   ypos2:  Y position of item 2
+ * @return          True if a swap would restore previous state
+ */
+bool Playfield_IsRestoringSwap(
     uint_fast8_t xpos1, uint_fast8_t ypos1,
     uint_fast8_t xpos2, uint_fast8_t ypos2);
 


### PR DESCRIPTION
Adds automatic undo feature.

This feature is in effect when the swap performed restores a previous swap, as long as no matches occurred between, but intentionally allowed even across a wave.