### PR TITLE
Missed an input for high score entry

### DIFF
--- a/src/gameover.c
+++ b/src/gameover.c
@@ -301,7 +301,7 @@ bool GameOver_Frame(void)
    if ((ctrl & CONTROL_LL_ACTION) != 0U){
     gameover_uppercase = !gameover_uppercase;
    }
-   if ((ctrl & CONTROL_LL_MENU) != 0U){
+   if (((ctrl & CONTROL_LL_ALTERN) != 0U) || ((ctrl & CONTROL_LL_MENU) != 0U)){
     if (gameover_cursor < (HISCORE_NAME_MAX)){
      gameover_cursor = HISCORE_NAME_MAX;
     }else{


### PR DESCRIPTION
Maintaining consistency with the rest of the game, the MENU and ALTERN controls are meant to be equivalent here. Easier to enter high score that way!