### PR TITLE
Background tileset tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ $(OBJDIR)/random.o: src/random.s $(DEPDIR)/random.d
 	$(CC) $(INCLUDES) $(ASMFLAGS) -c $< -o $@
 
 ## Generate resources
-$(OBJDIR)/tileset.s: assets/tileset.png tools/tilegen.py
+$(OBJDIR)/tileset.s: assets/tileset.png tools/tilegen_v2.py
 	$(PYTHON) tools/tilegen_v2.py $< $@
 
 $(OBJDIR)/spriteset.s: assets/spriteset.png tools/spritegen.py


### PR DESCRIPTION
The background tileset generator can now place the entry code and palette in the last block if it fits there. Saves some space in a location (.text) accessible for code placement, which is the case for this game as things are now.